### PR TITLE
Add needed libraries to install cryptography and broadlink on raspbian (RPI4)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONIOENCODING=utf-8
 #install pip3
 RUN apt update
 
-RUN apt install python3-pip --yes
+RUN apt install python3-pip libffi-dev libssl-dev --yes
 
 RUN  pip3 install flask flask_restful cryptography==2.6.1 broadlink --no-cache-dir
 


### PR DESCRIPTION
I needed to add these two libraries for it to build the image on raspbian in a raspberry pi 4 for armhf architectures. If they don't hurt in the amd64 one maybe can be added? Thanks