### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ services:
     image: techblog/broadlinkmanager
     network_mode: host
     container_name: broadlinkmanager
-    restart: always
     restart: unless-stopped
     volumes:
       - ./broadlinkmanager:/opt/broadlinkmanager/data


### PR DESCRIPTION
fix docker-compose error.
the error:
```
 yaml: unmarshal errors:
  line 8: mapping key "restart" already defined at line 7
```

solution: removed one of the restart properties in the yaml