### PR TITLE
feat: allow accessing broadlink controllers by referencing static ip.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,14 @@ version: "3.6"
 services:
   broadlinkmanager:
     image: techblog/broadlinkmanager
-    network_mode: host
+    network_mode: host  # Necessary to use discovery mode.
     container_name: broadlinkmanager
     restart: unless-stopped
     volumes:
       - ./broadlinkmanager:/opt/broadlinkmanager/data
     environment:
       - ENABLE_GOOGLE_ANALYTICS=True #Optional, default is True, Set to False if you want to disable Google Analytics
+      - STATIC_IP_LIST=192.168.1.100,192.168.1.101 # Optional. Direct ip reference to controllers in another subnet or when host networking can not be used.
 
 ```
 Now open your browser and enter your docker container ip with port 7020:


### PR DESCRIPTION
… This allows use of non-host network mode in docker and makes the app work properly on mac.

This will provide a solution for the following issues:
- https://github.com/t0mer/broadlinkmanager-docker/issues/81
- https://github.com/t0mer/broadlinkmanager-docker/issues/55
- https://github.com/t0mer/broadlinkmanager-docker/issues/13
- https://github.com/t0mer/broadlinkmanager-docker/issues/10

To confirm, the following docker-compose file can be used:


```yaml
services:
  broadlinkmanager:
    build: .
    environment:
      - ENABLE_GOOGLE_ANALYTICS=False
      - STATIC_IP_LIST=<ip-of-controller1>,<ip-of-controller2..>
    ports:
      - 7020:7020
```