### PR TITLE
 Update Docker Build workflow: modernize action versions and fix deprecated syntax

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,43 +5,38 @@ on:
   workflow_run:
     workflows: [Create Release]
     types:
-      - completed  
-
+      - completed
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
-      - name: Get current date
-        id: getDate
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Get semantic version from file
+      - name: Read version
         id: getSemver
-        run: echo "::set-output name=semver::$(cat broadlinkmanager/VERSION | tr -d ' \t\n\r' )"
-      
+        run: echo "semver=$(tr -d ' \t\n\r' < broadlinkmanager/VERSION)" >> $GITHUB_OUTPUT
+
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             techblog/broadlinkmanager:latest
-            techblog/broadlinkmanager:${{ steps.getSemver.outputs.semver }}       
+            techblog/broadlinkmanager:${{ steps.getSemver.outputs.semver }}
 


### PR DESCRIPTION
  ## Summary

  - Update all deprecated action versions in `docker-image.yml` to current majors
  - Fix deprecated `::set-output` syntax replaced with `>> $GITHUB_OUTPUT` 
  - Remove unused `getDate` step (the date was never referenced in the tags)

  ## Changes
  
  | Step | Before | After |
  |---|---|---|
  | Checkout | `actions/checkout@v2` | `actions/checkout@v4` |
  | QEMU | `docker/setup-qemu-action@v1` | `docker/setup-qemu-action@v3` |
  | Buildx | `docker/setup-buildx-action@v1` | `docker/setup-buildx-action@v3` |
  | Login | `docker/login-action@v1` | `docker/login-action@v3` |
  | Build & Push | `docker/build-push-action@v2` | `docker/build-push-action@v6` |
  | Output syntax | `echo "::set-output name=..."` | `echo "key=value" >> $GITHUB_OUTPUT` |

  ## Notes
  
  - `docker-jcr.yml` already uses current action versions — no changes needed
  - The Dockerfile's multi-stage build (Stage 1: Node/Vite for the React frontend, Stage 2: Python runtime) handles the UI build internally — no additional CI steps required in either workflow
  - Platforms unchanged: `linux/amd64,linux/arm64,linux/arm/v7`